### PR TITLE
Delete turbo_adapter.te

### DIFF
--- a/googlebattery/turbo_adapter.te
+++ b/googlebattery/turbo_adapter.te
@@ -1,3 +1,0 @@
-# To find and bind Google Battery HAL
-allow turbo_adapter hal_googlebattery_hwservice:hwservice_manager find;
-binder_call(turbo_adapter, hal_googlebattery)


### PR DESCRIPTION
we do not build the sepolicy rules for this app. this just causes a build break and needs to be removed